### PR TITLE
Add encryption and decryption methods

### DIFF
--- a/database.ts
+++ b/database.ts
@@ -19,6 +19,12 @@ export const responses = Datastore.create({
   timestampData: true,
 })
 
+export const researchers = Datastore.create({
+  filename: '.data/researchers',
+  autoload: true,
+  timestampData: true,
+})
+
 // export const db = {
 //   users: new Datastore({
 //     filename: ".data/users",

--- a/server.ts
+++ b/server.ts
@@ -9,7 +9,16 @@ import { users, surveys, responses } from "./database";
 import fetch from "node-fetch";
 import cookieParser = require("cookie-parser");
 import session = require("express-session");
+import crypto = require('crypto');
+import { Request, Response } from "express-serve-static-core";
+import { ParsedQs } from "qs";
 const app = express();
+
+const crypto_algorithm = 'aes-192-cbc';
+
+//PLACEHOLDER VALUES FOR CRYPTO. DO NOT USE FOR PRODUCTION. Replace 'researcherpassword' with researcher's password.
+const private_key_example = crypto.scryptSync('researcherpassword', 'salt', 24);
+const iv_example = crypto.randomBytes(16);
 
 app.use(cors());
 app.use(cookieParser());
@@ -49,11 +58,9 @@ app.get("/", (req, res) => {
   } else res.redirect("/survey");
 });
 
-// Test URL: https://raw.githubusercontent.com/Watts-Lab/surveyor/main/surveys/CRT.csv
-// e.g. http://localhost:4000/s/?url=https://raw.githubusercontent.com/Watts-Lab/surveyor/main/surveys/CRT.csv&name=Mark
-app.get("/s/", async (req, res) => {
+const getsurvey = async (urlstr: string, req: Request<{}>, res: Response<any>) =>  {
   try {
-    const survey_url = new URL(String(req.query.url));
+    const survey_url = new URL(urlstr);
     res.render("survey", {
       query: req.query,
       survey: await fetch(survey_url)
@@ -66,6 +73,30 @@ app.get("/s/", async (req, res) => {
   } catch (error) {
     console.error(error);
     res.redirect("/");
+  }
+}
+// Test URL: https://raw.githubusercontent.com/Watts-Lab/surveyor/main/surveys/CRT.csv
+// e.g. http://localhost:4000/s/?url=https://raw.githubusercontent.com/Watts-Lab/surveyor/main/surveys/CRT.csv&name=Mark
+app.get("/s/", async (req, res) => {
+
+  //For debugging purposes. Prints encrypted version of url. In the future, this will be done in researcher menu.
+  const cipher = crypto.createCipheriv(crypto_algorithm, private_key_example, iv_example);
+  let encrypted = cipher.update(String(req.query.url), 'utf8', 'hex');
+  console.log(encrypted += cipher.final('hex'));
+
+  getsurvey(String(req.query.url), req, res);
+});
+
+app.get('/e/:data', async (req, res) => {
+  //in the future, private_key and iv will be obtained through researcher database
+  try {
+    const decipher = crypto.createDecipheriv(crypto_algorithm, private_key_example, iv_example);
+    let decrypted = decipher.update(req.params.data, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    getsurvey(decrypted, req, res);
+  } catch (error) {
+    console.error(error);
+    res.redirect('/');
   }
 });
 

--- a/server.ts
+++ b/server.ts
@@ -58,9 +58,9 @@ app.get("/", (req, res) => {
   } else res.redirect("/survey");
 });
 
-const getsurvey = async (urlstr: string, req: Request<{}>, res: Response<any>) =>  {
+const getsurvey = async (query: string | ParsedQs, req: Request<{}>, res: Response<any>) =>  {
   try {
-    const survey_url = new URL(urlstr);
+    const survey_url = new URL(query['url']);
     res.render("survey", {
       query: req.query,
       survey: await fetch(survey_url)
@@ -78,13 +78,13 @@ const getsurvey = async (urlstr: string, req: Request<{}>, res: Response<any>) =
 // Test URL: https://raw.githubusercontent.com/Watts-Lab/surveyor/main/surveys/CRT.csv
 // e.g. http://localhost:4000/s/?url=https://raw.githubusercontent.com/Watts-Lab/surveyor/main/surveys/CRT.csv&name=Mark
 app.get("/s/", async (req, res) => {
-
   //For debugging purposes. Prints encrypted version of url. In the future, this will be done in researcher menu.
   const cipher = crypto.createCipheriv(crypto_algorithm, private_key_example, iv_example);
-  let encrypted = cipher.update(String(req.query.url), 'utf8', 'hex');
+  let encrypted = cipher.update(JSON.stringify(req.query), 'utf8', 'hex');
   console.log(encrypted += cipher.final('hex'));
 
-  getsurvey(String(req.query.url), req, res);
+  console.log(req.query);
+  getsurvey(req.query, req, res);
 });
 
 app.get('/e/:data', async (req, res) => {
@@ -93,7 +93,7 @@ app.get('/e/:data', async (req, res) => {
     const decipher = crypto.createDecipheriv(crypto_algorithm, private_key_example, iv_example);
     let decrypted = decipher.update(req.params.data, 'hex', 'utf8');
     decrypted += decipher.final('utf8');
-    getsurvey(decrypted, req, res);
+    getsurvey(JSON.parse(decrypted), req, res);
   } catch (error) {
     console.error(error);
     res.redirect('/');

--- a/server.ts
+++ b/server.ts
@@ -62,7 +62,7 @@ const getsurvey = async (query: string | ParsedQs, req: Request<{}>, res: Respon
   try {
     const survey_url = new URL(query['url']);
     res.render("survey", {
-      query: req.query,
+      query: query,
       survey: await fetch(survey_url)
         .then((response) => response.text())
         .then(parseCSV),


### PR DESCRIPTION
User can now use encrypted URLs by going to /e/:data.

Data stores the hash of the URL info that usually gets put in the query of /s/.

You can test the encrypted URL by first going to the /s/ and copy+paste the hash from the console log.

Put the hash after /e/, and the encrypted URL should work.