### PR TITLE
validations change flag

### DIFF
--- a/routes/links.ts
+++ b/routes/links.ts
@@ -55,41 +55,6 @@ router.post(`/link/survey`, verify_api_token, async (req, res) => {
 })
 
 
-
-/* THIS NEEDS TO BE AUTHENTICATED TO ADMIN USER
- Since this will be live.
- Current Hacky solution: Post enpoint root with random string 
- because someone not authenticate might
- stumble on to it when authentication is not set up.*/
-// Create New Link if it doesn't exist otherwise update
-
-//Note to self put this functionality in python backend services
-// will be deleted one I update the mturk hits pipeline not to depend on it
-router.post(`/link/${env_config.RANDOM}`, async (req, res) => {
-    const { alias, url } = req.body
-  
-    // Set old link if it exists to inactive
-    // With current logic there can only be one active link
-    await Db_Wrapper.update(
-      {alias, 'active': true}, {$set: {'active': false, 'end': Date().toString()}}, 
-      {}, 
-      'links'
-    )
-  
-    // create new alias if post request has been sent
-    // Only active link with this alias
-    await Db_Wrapper.insert({alias, url, 'hits': 0, 'active': true, 'start': Date().toString(), 'end': null}, 'links')
-    
-  
-    res.status(200).send('OK')
-  })
-
-  //Note to self put this functionality in python backend services
-  // will be deleted one I update the mturk hits pipeline
-router.get(`/link/${env_config.RANDOM}/:alias`, async (req, res) => {
-  const body = await Db_Wrapper.find({'alias': req.params.alias}, 'links')
-  res.status(200).send(body)
-})
 // Redirection To Mturk URL and increments count number
 router.get("/r/:alias", async (req, res) => {
   try { 

--- a/routes/survey.ts
+++ b/routes/survey.ts
@@ -136,19 +136,23 @@ router.get("/sa/:alias/", csrfProtection, async (req, res: Response) => {
   delete parsed['_id']
   
   // validations meta data
-  const validations = parsed.validations
+  const validations_start: string[] = parsed.validations_start
   // validations_first flag 1 is true, 0 is false
-  const validations_first = (parsed.validations_first != 0) 
+  const validations_end: string[] = parsed.validations_end
   req.session.query = parsed
-  req.session.validations_first = validations_first
-
-  if (validations != undefined) {
-    req.session.validations = validations
+  
+  if (validations_start) {
+    req.session.validations_start = validations_start
   }
-
-  if (validations == null || validations.length == 0 || validations_first == false) {  
+  if (validations_end) {
+    req.session.validations_end = validations_end
+  }
+  
+  if (validations_start == null || validations_start.length == 0) {  
+    req.session.start = false;
     res.redirect("/s")
   } else { // if validation_first is undefined it will default as first
+    req.session.start = true;
     res.redirect("/validate")
   }
 })
@@ -244,7 +248,7 @@ router.post("/survey", csrfProtection, exists_token, async (req, res) => {
   )
 
   if (!req.body["check"] || Number(req.body["curr_page"]) > Number(req.body["final"])) { 
-    if (req.session.validations_first == false) {
+    if (req.session.validations_end != undefined && req.session.validations_end.length != 0) {
       req.session.query = {}
       return res.redirect("/validate")
     }

--- a/routes/validation.ts
+++ b/routes/validation.ts
@@ -79,11 +79,11 @@ router.post("/challenge", csrfProtection, async (req, res: Response) => {
 
 router.get("/", csrfProtection, async (req, res: Response) => {
   // master function for all validation flags
-  
+  req.session.validations = req.session.start ? req.session.validations_start : req.session.validations_end
   if(req.session.validations.length == 0) { // if validations are empty
     // go back to normal survey logic
     delete req.session["validation"]
-    if (req.session.validations_first == false) {
+    if (req.session.start == false) {
       const completion_stamp = {...req.session.query, ...setSurveyCompleted()}
       
       await Db_Wrapper.update(
@@ -95,7 +95,7 @@ router.get("/", csrfProtection, async (req, res: Response) => {
 
       return res.redirect("/thanks")
     }
-
+    req.session.start = false;
     return res.redirect("/s/")
   }
 


### PR DESCRIPTION
We have more fine tune control of what validation go where and when. Previously, we could only put all validations at the start or the end. Now, we can decide for each validations. To do this, the request is the following in the body to the /link/survey endpoint with the x-access-token in the header.
https://www.loom.com/share/dd326fae550942499d1b5db69447665b
{
  "WorkerId": "sumant", 
  "SurveyName": "CRT", 
  "url": "https://raw.githubusercontent.com/Watts-Lab/surveyor/prod/surveys/CRT.csv", 
  "status": "active",
  "validations_start": ["captcha"],
  "validations_end": ["https://raw.githubusercontent.com/Watts-Lab/surveyor/testing-radio/surveys/challenge-surveys/Deceptive_Inattentive.csv", "captcha"]
}