### PR TITLE
Added Parsing of Queries to Alias Urls

### DIFF
--- a/routes/survey.ts
+++ b/routes/survey.ts
@@ -90,6 +90,16 @@ const getsurvey = async (query: string | ParsedQs, req: Request<{}>, res: Respon
     res.redirect("/");
   }
 }
+
+
+const add_query = (query: Object, parsed: Object) => {
+  Object.entries(query).forEach(([key, value]) => {
+    if (parsed[key] === undefined) { // never overwrites parsed params
+      parsed[key] = value;
+    }
+  });
+}
+
   // Test URL: https://raw.githubusercontent.com/Watts-Lab/surveyor/main/surveys/CRT.csv
 // e.g. http://localhost:4000/s/?url=https://raw.githubusercontent.com/Watts-Lab/surveyor/main/surveys/CRT.csv&name=Mark
 router.get("/s/", csrfProtection, async (req, res) => {
@@ -121,8 +131,12 @@ router.get("/sa/:alias/", csrfProtection, async (req, res: Response) => {
     return res.status(400).send('Invalid URL. Please Email Researcher for url')
   }
 
-  const parsed = record[0]
+  let parsed = record[0]
 
+  // queryies in the url
+  if (req.query) {
+    add_query(req.query, parsed);
+  }
   if (parsed.status == 'inactive') {
     return res.status(400).send("URL has expired.")
   }
@@ -163,14 +177,7 @@ router.get("/se/:encrypted", csrfProtection, async (req, res) => {
     const decrypted = decrypt(encrypted)
     const parsed = await JSON.parse(decrypted)
     
-    // queryies in the url
-    const queries: Object = req.query
-
-    Object.entries(queries).forEach(([key, value]) => { // encrypted takes precedence
-      if (parsed[key] === undefined) {
-        parsed[key] = value
-      }
-    })
+    add_query(req.query, parsed)
 
     if (!(parsed.url)) { // only query require is url
       return res.status(400).send("Wrong encryption. No URL is found.")


### PR DESCRIPTION
https://www.loom.com/share/d0c3d78a22f3412aa44ed15cd27ba716

A functionality that is added here is the ability to create alias urls, which point to a entry on mongo database, and also added additional queries to the url. Previously, we were able to create alias, but not add adhoc query parameters. This pull request builds functionality of adding query parameter that end up in the response.